### PR TITLE
Bugfix/fixed workinghours apply

### DIFF
--- a/workinghours-apply
+++ b/workinghours-apply
@@ -16,7 +16,7 @@ trap "rm -f $tmpfile" EXIT
 cat $2 > $tmpfile
 
 cd "$repo" || exit 1
-WH_PLAN=$tmpfile git filter-branch -f --tree-filter '
+WH_PLAN=$tmpfile git filter-branch -f --env-filter '
 when=$(awk -vcid=$GIT_COMMIT "\$1 == cid {print \$2}" $WH_PLAN)
 [ "$when" ] && export GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when"
 ' HEAD

--- a/workinghours-apply
+++ b/workinghours-apply
@@ -8,7 +8,7 @@
 # Defaults to using the current directory if you do not provide an
 # explicit repository path.
 
-repo=$(readlink -f ${1:-.})
+repo=$(readlink -f "${1:-.}")
 tmpfile=$(mktemp -t planXXXXXX)
 trap "rm -f $tmpfile" EXIT
 


### PR DESCRIPTION
I played with your hack for fun, but the `workinghours-apply` script is not working (anymore). I fixed the issue (missing export of the `WH_PLAN` variable), made the script more readable and also made repository paths with spaces working.

Why you used `tree-filter` instead of `env-filter`?